### PR TITLE
Drop ampersand hotkey markers and preserve string.Format placeholders during translation

### DIFF
--- a/Action/ActionInputs.cs
+++ b/Action/ActionInputs.cs
@@ -20,6 +20,14 @@ public class ActionInputs : IActionInputs
     public string AuthKey { get; set; } = "";
         
     [Option(
+        's', 
+        "source-lang",
+        Required = false,
+        Default = "",
+        HelpText = "The language used in the original ResX files. Leave empty to auto-detect.")]
+    public string SourceLang { get; set; } = "";
+        
+    [Option(
         'e', 
         "excludes-regex",
         Required = false,
@@ -60,5 +68,5 @@ public class ActionInputs : IActionInputs
     public string LocalizationExcludes { get; set; } = "";
 
     public override string ToString() => 
-        $"{nameof(Directory)}: {Directory}, {nameof(AuthKey)}: {AuthKey}, {nameof(ExcludesRegex)}: {ExcludesRegex}, {nameof(DataCopiesRegex)}: {DataCopiesRegex}, {nameof(TakeOverridesKeysSuperSetAsKeyFilter)}: {TakeOverridesKeysSuperSetAsKeyFilter}, {nameof(LocalizationFilter)}: {LocalizationFilter}, {nameof(LocalizationExcludes)}: {LocalizationExcludes}";
+        $"{nameof(Directory)}: {Directory}, {nameof(AuthKey)}: {AuthKey}, {nameof(SourceLang)}: {SourceLang}, {nameof(ExcludesRegex)}: {ExcludesRegex}, {nameof(DataCopiesRegex)}: {DataCopiesRegex}, {nameof(TakeOverridesKeysSuperSetAsKeyFilter)}: {TakeOverridesKeysSuperSetAsKeyFilter}, {nameof(LocalizationFilter)}: {LocalizationFilter}, {nameof(LocalizationExcludes)}: {LocalizationExcludes}";
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Set the base image as the .NET 5.0 SDK (this includes the runtime)
-FROM mcr.microsoft.com/dotnet/sdk:5.0 as build-env
+# Set the base image as the .NET 6.0 SDK (this includes the runtime)
+FROM mcr.microsoft.com/dotnet/sdk:6.0 as build-env
 
 # Copy everything and publish the release (publish implicitly restores and builds)
 COPY . ./
@@ -16,4 +16,4 @@ LABEL com.github.actions.description="A Github action that searches for default,
 LABEL com.github.actions.icon="file-plus"
 LABEL com.github.actions.color="purple"
 
-ENTRYPOINT [ "dotnet", "/Action/bin/Release/net5.0/MrMeeseeks.ResXTranslationCombinator.Action.dll" ]
+ENTRYPOINT [ "dotnet", "/Action/bin/Release/net6.0/MrMeeseeks.ResXTranslationCombinator.Action.dll" ]

--- a/Main/IActionInputs.cs
+++ b/Main/IActionInputs.cs
@@ -4,6 +4,7 @@ public interface IActionInputs
 {
     string Directory { get; }
     string AuthKey { get; }
+    string SourceLang { get; }
     string ExcludesRegex { get; }
     string DataCopiesRegex { get; }
     bool TakeOverridesKeysSuperSetAsKeyFilter { get; } 

--- a/Main/Translation/DeepLTranslator.cs
+++ b/Main/Translation/DeepLTranslator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using DeepL;
 using MrMeeseeks.ResXTranslationCombinator.Utility;
@@ -50,6 +51,8 @@ internal class DeepLTranslator : IDeepLTranslator
         }
     }
 
+    private static readonly Regex HotkeyPrefixRegex = new("&([a-zA-Z0-9])", RegexOptions.Compiled);
+
     public async Task<string[]> Translate(
         string[] sourceTexts, 
         CultureInfo targetLanguageCode)
@@ -57,7 +60,7 @@ internal class DeepLTranslator : IDeepLTranslator
         try
         {
             var translations = await _deepLClient.TranslateTextAsync(
-                sourceTexts,
+                sourceTexts.Select(t => HotkeyPrefixRegex.Replace(t, "$1")),
                 null,
                 targetLanguageCode.Name,
                 new TextTranslateOptions

--- a/Main/Translation/DeepLTranslator.cs
+++ b/Main/Translation/DeepLTranslator.cs
@@ -17,6 +17,7 @@ internal class DeepLTranslator : IDeepLTranslator
     private readonly ILogger _logger;
     private readonly Translator _deepLClient;
     private IImmutableSet<CultureInfo>? _cachedSupportedCultureInfos;
+    private string? _sourceLanguage;
 
     public DeepLTranslator(
         IActionInputs actionInputs,
@@ -25,6 +26,7 @@ internal class DeepLTranslator : IDeepLTranslator
     {
         _logger = logger;
         _deepLClient = deepLClientFactory(actionInputs.AuthKey);
+        _sourceLanguage = string.IsNullOrEmpty(actionInputs.SourceLang) ? null : actionInputs.SourceLang;
     }
 
     public bool TranslationsShouldBeCached => true;
@@ -66,7 +68,7 @@ internal class DeepLTranslator : IDeepLTranslator
                 sourceTexts.Select(t => PlaceholderRegex.Replace(
                     HttpUtility.HtmlEncode(HotkeyPrefixRegex.Replace(t, "$1")),
                     "<placeholder>$1</placeholder>")),
-                null,
+                _sourceLanguage,
                 targetLanguageCode.Name,
                 new TextTranslateOptions
                 {

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   auth:
     description: 'Auth key for your DeepL API access.'
     required: true
+  source-lang:
+    description: 'The language used in the original ResX files. Leave empty to auto-detect.'
+    required: false
+    default: ''    
   excludes-regex:
     description: 'Regex for names of default ResX files in order to decide whether to exclude file from processing.'
     required: false
@@ -44,6 +48,8 @@ runs:
   - ${{ inputs.dir }}
   - '-a'
   - ${{ inputs.auth }}
+  - '-s'
+  - ${{ inputs.source-lang }}
   - '-e'
   - ${{ inputs.excludes-regex }}
   - '-c'


### PR DESCRIPTION
Resolves #3 and #4.

Adds the ability to configure the source language instead of auto-detect.