### PR TITLE
Add support for colons inside placeholders

### DIFF
--- a/Main/Translation/DeepLTranslator.cs
+++ b/Main/Translation/DeepLTranslator.cs
@@ -59,8 +59,8 @@ internal class DeepLTranslator : IDeepLTranslator, IContainerInstance
     }
 
     private static readonly Regex HotkeyPrefixRegex = new("&([a-zA-Z0-9])", RegexOptions.Compiled);
-    private static readonly Regex PlaceholderRegex = new("{([a-zA-Z0-9]+)}", RegexOptions.Compiled);
-    private static readonly Regex PlaceholderReverseRegex = new("<placeholder>([a-zA-Z0-9]+)</placeholder>", RegexOptions.Compiled);
+    private static readonly Regex PlaceholderRegex = new("{([a-zA-Z0-9:]+)}", RegexOptions.Compiled);
+    private static readonly Regex PlaceholderReverseRegex = new("<placeholder>([a-zA-Z0-9:]+)</placeholder>", RegexOptions.Compiled);
 
     public async Task<string[]> Translate(
         string[] sourceTexts, 


### PR DESCRIPTION
This enables more complex `string.Format()` expressions like `"Money: {0:C}"`.