### PR TITLE
Add support for additional context

### DIFF
--- a/Action/ActionInputs.cs
+++ b/Action/ActionInputs.cs
@@ -34,6 +34,14 @@ public class ActionInputs : IActionInputs
         Default = "",
         HelpText = "The name of the glossary to use for translation. Only works if source-lang is also set.")]
     public string GlossaryName { get; set; } = "";
+
+    [Option(
+        't',
+        "context",
+        Required = false,
+        Default = "",
+        HelpText = "Free-form text to provide additional context for the contents of the ResX files.")]
+    public string Context { get; set; } = "";
         
     [Option(
         'e', 

--- a/Main/IActionInputs.cs
+++ b/Main/IActionInputs.cs
@@ -6,6 +6,7 @@ public interface IActionInputs
     string AuthKey { get; }
     string SourceLang { get; }
     string GlossaryName { get; }
+    string Context { get; }
     string ExcludesRegex { get; }
     string DataCopiesRegex { get; }
     bool TakeOverridesKeysSuperSetAsKeyFilter { get; } 

--- a/Main/Main.csproj
+++ b/Main/Main.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DeepL.net" Version="1.5.0" />
-    <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="DeepL.net" Version="1.8.0" />
+    <PackageReference Include="morelinq" Version="4.1.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Main/Translation/DeepLTranslator.cs
+++ b/Main/Translation/DeepLTranslator.cs
@@ -21,6 +21,7 @@ internal class DeepLTranslator : IDeepLTranslator, IContainerInstance
     private IImmutableSet<CultureInfo>? _cachedSupportedCultureInfos;
     private string? _sourceLanguage;
     private string? _glossaryName;
+    private string? _context;
 
     public DeepLTranslator(
         IActionInputs actionInputs,
@@ -31,6 +32,7 @@ internal class DeepLTranslator : IDeepLTranslator, IContainerInstance
         _deepLClient = deepLClientFactory(actionInputs.AuthKey);
         _sourceLanguage = string.IsNullOrEmpty(actionInputs.SourceLang) ? null : actionInputs.SourceLang;
         _glossaryName = string.IsNullOrEmpty(actionInputs.GlossaryName) ? null : actionInputs.GlossaryName;
+        _context = string.IsNullOrEmpty(actionInputs.Context) ? null : actionInputs.Context;
     }
 
     public bool TranslationsShouldBeCached => true;
@@ -90,7 +92,8 @@ internal class DeepLTranslator : IDeepLTranslator, IContainerInstance
                     PreserveFormatting = true,
                     TagHandling = "xml",
                     IgnoreTags = { "placeholder" },
-                    GlossaryId = glossary?.GlossaryId
+                    GlossaryId = glossary?.GlossaryId,
+                    Context = _context
                 }
             );
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'The name of the glossary to use for translation. Only works if source-lang is also set.'
     required: false
     default: ''
+  context:
+    description: 'Free-form text to provide additional context for the contents of the ResX files.'
+    required: false
+    default: ''
   excludes-regex:
     description: 'Regex for names of default ResX files in order to decide whether to exclude file from processing.'
     required: false
@@ -56,6 +60,8 @@ runs:
   - ${{ inputs.source-lang }}
   - '-g'
   - ${{ inputs.glossary-name }}
+  - '-t'
+  - ${{ inputs.context }}
   - '-e'
   - ${{ inputs.excludes-regex }}
   - '-c'


### PR DESCRIPTION
This adds a new `context` option, allowing users to specify free-form text to provide additional context for the contents of the ResX files. DeepL can use this provide higher quality translations, especially of very short strings.